### PR TITLE
Add island world auto-saving and SSBProxyBridge support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ build
 # Ignore output generated files
 target
 out
+
+# Ignore local dependency jars
+archive

--- a/API/src/main/java/com/bgsoftware/ssbslimeworldmanager/api/SlimeWorldLoadException.java
+++ b/API/src/main/java/com/bgsoftware/ssbslimeworldmanager/api/SlimeWorldLoadException.java
@@ -1,0 +1,24 @@
+package com.bgsoftware.ssbslimeworldmanager.api;
+
+/**
+ * Thrown when an island world could not be loaded from the data-source.
+ * <p>
+ * The most common cause on a network is that the world is still locked by another server that
+ * has not released it yet - for example a server that crashed while the island was loaded.
+ * Callers are expected to handle this and retry later instead of assuming the world exists.
+ */
+public class SlimeWorldLoadException extends RuntimeException {
+
+    private final String worldName;
+
+    public SlimeWorldLoadException(String worldName) {
+        super("Failed to create or load island world \"" + worldName + "\". " +
+                "It may be corrupted, or still locked by another server.");
+        this.worldName = worldName;
+    }
+
+    public String getWorldName() {
+        return worldName;
+    }
+
+}

--- a/src/main/java/com/bgsoftware/ssbslimeworldmanager/SlimeWorldModule.java
+++ b/src/main/java/com/bgsoftware/ssbslimeworldmanager/SlimeWorldModule.java
@@ -7,19 +7,22 @@ import com.bgsoftware.ssbslimeworldmanager.config.SettingsManager;
 import com.bgsoftware.ssbslimeworldmanager.hook.SlimeWorldsCreationAlgorithm;
 import com.bgsoftware.ssbslimeworldmanager.hook.SlimeWorldsProvider;
 import com.bgsoftware.ssbslimeworldmanager.listeners.IslandsListener;
+import com.bgsoftware.ssbslimeworldmanager.listeners.SaveTriggersListener;
 import com.bgsoftware.ssbslimeworldmanager.listeners.WorldsListener;
 import com.bgsoftware.ssbslimeworldmanager.providers.ProvidersManager;
+import com.bgsoftware.ssbslimeworldmanager.save.IslandWorldsSaveService;
 import com.bgsoftware.superiorskyblock.api.SuperiorSkyblock;
 import com.bgsoftware.superiorskyblock.api.commands.SuperiorCommand;
 import com.bgsoftware.superiorskyblock.api.modules.ModuleLoadTime;
 import com.bgsoftware.superiorskyblock.api.modules.PluginModule;
 import com.bgsoftware.superiorskyblock.api.world.algorithm.IslandCreationAlgorithm;
 import org.bukkit.Bukkit;
+import org.bukkit.World;
 import org.bukkit.event.Listener;
 
 import javax.annotation.Nullable;
-import java.io.IOException;
 import java.lang.reflect.Constructor;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 
@@ -34,6 +37,7 @@ public class SlimeWorldModule extends PluginModule {
     @Nullable
     private ISlimeAdapter slimeAdapter;
     private SlimeWorldsProvider slimeWorldsProvider;
+    private IslandWorldsSaveService saveService;
 
     public SlimeWorldModule() {
         super("SlimeWorldIslands", "Ome_R");
@@ -55,6 +59,9 @@ public class SlimeWorldModule extends PluginModule {
 
         loadCreationAlgorithm();
 
+        this.saveService = new IslandWorldsSaveService(this);
+        this.saveService.start();
+
         this.providersManager.loadHooks();
     }
 
@@ -65,29 +72,28 @@ public class SlimeWorldModule extends PluginModule {
 
     @Override
     public void onDisable(SuperiorSkyblock plugin) {
+        if (this.saveService != null)
+            this.saveService.stop();
+
         if (slimeAdapter == null)
             return;
 
-        List<String> worlds;
-
-        try {
-            worlds = slimeAdapter.getSavedWorlds();
-        } catch (IOException error) {
-            error.printStackTrace();
-            return;
+        // Save all the islands when the server shuts down.
+        // We iterate the loaded worlds instead of the saved ones, so islands that were never
+        // written to the data-source before are saved as well.
+        List<String> loadedIslandWorlds = new LinkedList<>();
+        for (World world : Bukkit.getWorlds()) {
+            if (SlimeUtils.isIslandsWorld(world.getName()) || SlimeUtils.isIslandWorldName(world.getName()))
+                loadedIslandWorlds.add(world.getName());
         }
 
-        // Save all the islands when the server shuts down
-        for (String worldName : worlds) {
-            if (SlimeUtils.isIslandWorldName(worldName) && Bukkit.getWorld(worldName) != null) {
-                SlimeUtils.saveAndUnloadWorld(worldName);
-            }
-        }
+        for (String worldName : loadedIslandWorlds)
+            SlimeUtils.saveAndUnloadWorld(worldName);
     }
 
     @Override
     public Listener[] getModuleListeners(SuperiorSkyblock plugin) {
-        return new Listener[]{new IslandsListener(this), new WorldsListener()};
+        return new Listener[]{new IslandsListener(this), new WorldsListener(this), new SaveTriggersListener(this)};
     }
 
     @Nullable
@@ -121,6 +127,10 @@ public class SlimeWorldModule extends PluginModule {
 
     public SlimeWorldsProvider getSlimeWorldsProvider() {
         return slimeWorldsProvider;
+    }
+
+    public IslandWorldsSaveService getSaveService() {
+        return saveService;
     }
 
     public SuperiorSkyblock getPlugin() {

--- a/src/main/java/com/bgsoftware/ssbslimeworldmanager/config/SettingsManager.java
+++ b/src/main/java/com/bgsoftware/ssbslimeworldmanager/config/SettingsManager.java
@@ -3,14 +3,25 @@ package com.bgsoftware.ssbslimeworldmanager.config;
 import com.bgsoftware.common.config.CommentedConfiguration;
 import com.bgsoftware.ssbslimeworldmanager.SlimeWorldModule;
 import com.bgsoftware.ssbslimeworldmanager.api.DataSourceParams;
+import com.bgsoftware.ssbslimeworldmanager.save.SaveReason;
 
 import java.io.File;
+import java.util.EnumSet;
+import java.util.Set;
 
 public class SettingsManager {
 
     public final DataSourceParams dataSource;
     public final int unloadDelay;
     public final boolean teleportBackToIsland;
+    public final boolean preloadIslandWorldsOnJoin;
+
+    public final boolean autoSaveEnabled;
+    public final long autoSaveInterval;
+    public final long autoSaveMinDelay;
+    public final int autoSaveSavesPerCycle;
+
+    private final Set<SaveReason> enabledSaveTriggers = EnumSet.noneOf(SaveReason.class);
 
     public SettingsManager(SlimeWorldModule module) {
         File file = new File(module.getModuleFolder(), "config.yml");
@@ -30,6 +41,21 @@ public class SettingsManager {
         this.dataSource = DataSourceParams.parse(config.getConfigurationSection("data-source"));
         this.unloadDelay = config.getInt("unload-delay");
         this.teleportBackToIsland = config.getBoolean("teleport-back-to-island", true);
+        this.preloadIslandWorldsOnJoin = config.getBoolean("preload-island-worlds-on-join", true);
+
+        this.autoSaveEnabled = config.getBoolean("auto-save.enabled", true);
+        this.autoSaveInterval = Math.max(config.getLong("auto-save.interval", 300L), 0L);
+        this.autoSaveMinDelay = Math.max(config.getLong("auto-save.min-delay", 60L), 0L);
+        this.autoSaveSavesPerCycle = Math.max(config.getInt("auto-save.saves-per-cycle", 1), 1);
+
+        for (SaveReason saveReason : SaveReason.values()) {
+            if (saveReason.isTrigger() && config.getBoolean("auto-save.triggers." + saveReason.getConfigKey(), true))
+                this.enabledSaveTriggers.add(saveReason);
+        }
+    }
+
+    public boolean isSaveTriggerEnabled(SaveReason saveReason) {
+        return this.enabledSaveTriggers.contains(saveReason);
     }
 
     private static void convertData(CommentedConfiguration config) {

--- a/src/main/java/com/bgsoftware/ssbslimeworldmanager/hook/SlimeWorldsProvider.java
+++ b/src/main/java/com/bgsoftware/ssbslimeworldmanager/hook/SlimeWorldsProvider.java
@@ -3,6 +3,7 @@ package com.bgsoftware.ssbslimeworldmanager.hook;
 import com.bgsoftware.ssbslimeworldmanager.SlimeWorldModule;
 import com.bgsoftware.ssbslimeworldmanager.api.ISlimeWorld;
 import com.bgsoftware.ssbslimeworldmanager.api.SlimeUtils;
+import com.bgsoftware.ssbslimeworldmanager.api.SlimeWorldLoadException;
 import com.bgsoftware.ssbslimeworldmanager.tasks.WorldUnloadTask;
 import com.bgsoftware.ssbslimeworldmanager.utils.Dimensions;
 import com.bgsoftware.superiorskyblock.api.config.SettingsManager;
@@ -198,6 +199,14 @@ public class SlimeWorldsProvider implements LazyWorldsProvider {
     private World getSlimeWorldAsBukkitLocked(String worldName, Dimension dimension, @Nullable PendingWorldLoadRequest pendingRequest) {
         // We load the world synchronized as we need it right now.
         ISlimeWorld slimeWorld = this.module.getSlimeAdapter().createOrLoadWorld(worldName, dimension);
+
+        if (slimeWorld == null) {
+            SlimeWorldLoadException error = new SlimeWorldLoadException(worldName);
+            if (pendingRequest != null)
+                pendingRequest.completeExceptionally(error);
+            throw error;
+        }
+
         World bukkitWorld = generateWorld(slimeWorld);
 
         WorldUnloadTask.getTask(slimeWorld.getName()).updateTimeUntilNextUnload();
@@ -240,15 +249,30 @@ public class SlimeWorldsProvider implements LazyWorldsProvider {
                 slimeWorld = this.module.getSlimeAdapter().createOrLoadWorld(worldName, dimension);
             }
 
+            if (slimeWorld == null) {
+                // The world could not be loaded - most likely it is still locked by another server.
+                // We must complete the request, otherwise every caller waiting on it hangs forever.
+                pendingWorldRequests.remove(worldName);
+                result.completeExceptionally(new SlimeWorldLoadException(worldName));
+                return;
+            }
+
             Bukkit.getScheduler().runTask(module.getPlugin(), () -> {
                 World bukkitWorld;
-                synchronized (result.mutex) {
-                    if (result.isStopped)
-                        return;
+                try {
+                    synchronized (result.mutex) {
+                        if (result.isStopped)
+                            return;
 
-                    // Generating the world synchronized
-                    bukkitWorld = generateWorld(slimeWorld);
+                        // Generating the world synchronized
+                        bukkitWorld = generateWorld(slimeWorld);
+                    }
+                } catch (Throwable error) {
+                    pendingWorldRequests.remove(worldName);
+                    result.completeExceptionally(error);
+                    return;
                 }
+
                 pendingWorldRequests.remove(worldName);
 
                 islandWorldsToDimensions.put(bukkitWorld.getUID(), dimension);

--- a/src/main/java/com/bgsoftware/ssbslimeworldmanager/listeners/IslandsListener.java
+++ b/src/main/java/com/bgsoftware/ssbslimeworldmanager/listeners/IslandsListener.java
@@ -52,6 +52,9 @@ public class IslandsListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerJoin(PlayerJoinEvent event) {
+        if (!module.getSettings().preloadIslandWorldsOnJoin)
+            return;
+
         SuperiorPlayer superiorPlayer = module.getPlugin().getPlayers().getSuperiorPlayer(event.getPlayer());
         Island island = superiorPlayer.getIsland();
         if (island != null) {

--- a/src/main/java/com/bgsoftware/ssbslimeworldmanager/listeners/SaveTriggersListener.java
+++ b/src/main/java/com/bgsoftware/ssbslimeworldmanager/listeners/SaveTriggersListener.java
@@ -1,0 +1,63 @@
+package com.bgsoftware.ssbslimeworldmanager.listeners;
+
+import com.bgsoftware.ssbslimeworldmanager.SlimeWorldModule;
+import com.bgsoftware.ssbslimeworldmanager.save.SaveReason;
+import com.bgsoftware.superiorskyblock.api.events.IslandBiomeChangeEvent;
+import com.bgsoftware.superiorskyblock.api.events.IslandLeaveEvent;
+import com.bgsoftware.superiorskyblock.api.events.IslandSchematicPasteEvent;
+import com.bgsoftware.superiorskyblock.api.events.IslandUpgradeEvent;
+import org.bukkit.World;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerChangedWorldEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+/**
+ * Requests saves of island worlds when something meaningful happened to them.
+ * Every request is throttled by the `auto-save.min-delay` setting.
+ */
+public class SaveTriggersListener implements Listener {
+
+    private final SlimeWorldModule module;
+
+    public SaveTriggersListener(SlimeWorldModule module) {
+        this.module = module;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onIslandLeave(IslandLeaveEvent event) {
+        module.getSaveService().requestSave(event.getIsland(), SaveReason.ISLAND_LEAVE);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onIslandUpgrade(IslandUpgradeEvent event) {
+        module.getSaveService().requestSave(event.getIsland(), SaveReason.ISLAND_UPGRADE);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onIslandSchematicPaste(IslandSchematicPasteEvent event) {
+        module.getSaveService().requestSave(event.getIsland(), SaveReason.SCHEMATIC_PASTE);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onIslandBiomeChange(IslandBiomeChangeEvent event) {
+        module.getSaveService().requestSave(event.getIsland(), SaveReason.BIOME_CHANGE);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerChangedWorld(PlayerChangedWorldEvent event) {
+        World from = event.getFrom();
+        if (from.getPlayers().isEmpty())
+            module.getSaveService().requestSave(from, SaveReason.WORLD_EMPTY);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        World world = event.getPlayer().getWorld();
+        // The quitting player is still counted as a player of the world at this point.
+        if (world.getPlayers().size() <= 1)
+            module.getSaveService().requestSave(world, SaveReason.WORLD_EMPTY);
+    }
+
+}

--- a/src/main/java/com/bgsoftware/ssbslimeworldmanager/listeners/WorldsListener.java
+++ b/src/main/java/com/bgsoftware/ssbslimeworldmanager/listeners/WorldsListener.java
@@ -1,5 +1,6 @@
 package com.bgsoftware.ssbslimeworldmanager.listeners;
 
+import com.bgsoftware.ssbslimeworldmanager.SlimeWorldModule;
 import com.bgsoftware.ssbslimeworldmanager.api.SlimeUtils;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -8,9 +9,18 @@ import org.bukkit.event.world.WorldUnloadEvent;
 
 public class WorldsListener implements Listener {
 
+    private final SlimeWorldModule module;
+
+    public WorldsListener(SlimeWorldModule module) {
+        this.module = module;
+    }
+
     @EventHandler(priority = EventPriority.MONITOR)
     public void onWorldUnload(WorldUnloadEvent e) {
         SlimeUtils.notifyUnloadWorld(e.getWorld());
+
+        if (module.getSaveService() != null)
+            module.getSaveService().notifyWorldUnloaded(e.getWorld().getName());
     }
 
 }

--- a/src/main/java/com/bgsoftware/ssbslimeworldmanager/save/IslandWorldsSaveService.java
+++ b/src/main/java/com/bgsoftware/ssbslimeworldmanager/save/IslandWorldsSaveService.java
@@ -1,0 +1,208 @@
+package com.bgsoftware.ssbslimeworldmanager.save;
+
+import com.bgsoftware.ssbslimeworldmanager.SlimeWorldModule;
+import com.bgsoftware.ssbslimeworldmanager.api.SlimeUtils;
+import com.bgsoftware.superiorskyblock.api.island.Island;
+import com.bgsoftware.superiorskyblock.api.world.Dimension;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.scheduler.BukkitTask;
+
+import javax.annotation.Nullable;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+
+/**
+ * Saves loaded island worlds to the data-source while they are still loaded.
+ * <p>
+ * Without this service, an island world is only written to the data-source when it is unloaded
+ * ({@link com.bgsoftware.ssbslimeworldmanager.tasks.WorldUnloadTask}) or when the server shuts
+ * down gracefully. A hard crash therefore reverts every loaded island back to its last save.
+ * <p>
+ * Saves are requested, never performed directly: every request goes into a queue that is drained
+ * once a second, and a world is skipped as long as it was saved less than `min-delay` ago. This
+ * keeps a burst of triggers (many players leaving at once, a wave of upgrades) from turning into
+ * a burst of disk/database writes.
+ */
+public class IslandWorldsSaveService {
+
+    private static final long CYCLE_INTERVAL_TICKS = 20L;
+
+    private final Map<String, Long> lastSaveTimes = new ConcurrentHashMap<>();
+    private final Map<String, SaveReason> pendingSaves = new LinkedHashMap<>();
+
+    private final SlimeWorldModule module;
+
+    @Nullable
+    private BukkitTask cycleTask;
+    @Nullable
+    private BukkitTask autoSaveTask;
+
+    public IslandWorldsSaveService(SlimeWorldModule module) {
+        this.module = module;
+    }
+
+    public void start() {
+        if (!module.getSettings().autoSaveEnabled)
+            return;
+
+        this.cycleTask = Bukkit.getScheduler().runTaskTimer(module.getPlugin(), this::runCycle,
+                CYCLE_INTERVAL_TICKS, CYCLE_INTERVAL_TICKS);
+
+        long intervalTicks = module.getSettings().autoSaveInterval * 20L;
+        if (intervalTicks > 0) {
+            this.autoSaveTask = Bukkit.getScheduler().runTaskTimer(module.getPlugin(),
+                    this::requestSaveForAllLoadedWorlds, intervalTicks, intervalTicks);
+        }
+    }
+
+    public void stop() {
+        if (this.cycleTask != null) {
+            this.cycleTask.cancel();
+            this.cycleTask = null;
+        }
+        if (this.autoSaveTask != null) {
+            this.autoSaveTask.cancel();
+            this.autoSaveTask = null;
+        }
+        synchronized (this.pendingSaves) {
+            this.pendingSaves.clear();
+        }
+    }
+
+    /**
+     * Request a save for all the loaded worlds of an island.
+     * The save is not guaranteed to happen immediately - see {@link #requestSave(World, SaveReason)}.
+     */
+    public void requestSave(Island island, SaveReason reason) {
+        if (island == null || island.isSpawn())
+            return;
+
+        for (Dimension dimension : Dimension.values()) {
+            World world = Bukkit.getWorld(SlimeUtils.getWorldName(island.getUniqueId(), dimension));
+            if (world != null)
+                requestSave(world, reason);
+        }
+    }
+
+    /**
+     * Request a save for a loaded island world.
+     * <p>
+     * The request is ignored when auto-saving is disabled, when the given reason is a trigger that
+     * was turned off in the config, or when the world is not an island world. Otherwise the world is
+     * queued, and it will be saved by the next cycle in which `min-delay` has passed since its last save.
+     */
+    public void requestSave(World world, SaveReason reason) {
+        if (world == null || !module.getSettings().autoSaveEnabled)
+            return;
+
+        if (reason.isTrigger() && !module.getSettings().isSaveTriggerEnabled(reason))
+            return;
+
+        if (!SlimeUtils.isIslandsWorld(world.getName()))
+            return;
+
+        synchronized (this.pendingSaves) {
+            // The first reason that queued the world is the one we report, as it is the one that
+            // actually caused the save to be scheduled.
+            if (!this.pendingSaves.containsKey(world.getName()))
+                this.pendingSaves.put(world.getName(), reason);
+        }
+    }
+
+    /**
+     * Save a loaded island world right now, ignoring `min-delay`.
+     * Should only be used for shutdown-like flows - regular callers want {@link #requestSave(World, SaveReason)}.
+     */
+    public void saveNow(World world, SaveReason reason) {
+        synchronized (this.pendingSaves) {
+            this.pendingSaves.remove(world.getName());
+        }
+        saveWorldInternal(world, reason);
+    }
+
+    /**
+     * Drop all the state we hold for a world that is no longer loaded.
+     */
+    public void notifyWorldUnloaded(String worldName) {
+        synchronized (this.pendingSaves) {
+            this.pendingSaves.remove(worldName);
+        }
+        this.lastSaveTimes.remove(worldName);
+    }
+
+    public long getLastSaveTime(String worldName) {
+        Long lastSaveTime = this.lastSaveTimes.get(worldName);
+        return lastSaveTime == null ? 0L : lastSaveTime;
+    }
+
+    private void requestSaveForAllLoadedWorlds() {
+        for (World world : Bukkit.getWorlds())
+            requestSave(world, SaveReason.AUTO_SAVE);
+    }
+
+    private void runCycle() {
+        int savesLeft = module.getSettings().autoSaveSavesPerCycle;
+        if (savesLeft <= 0)
+            return;
+
+        long minDelay = module.getSettings().autoSaveMinDelay * 1000L;
+        long currentTime = System.currentTimeMillis();
+
+        while (savesLeft > 0) {
+            String worldName = null;
+            SaveReason reason = null;
+
+            synchronized (this.pendingSaves) {
+                Iterator<Map.Entry<String, SaveReason>> iterator = this.pendingSaves.entrySet().iterator();
+                while (iterator.hasNext()) {
+                    Map.Entry<String, SaveReason> entry = iterator.next();
+
+                    if (currentTime - getLastSaveTime(entry.getKey()) < minDelay) {
+                        // Saved too recently; keep it queued so it is saved once the delay has passed.
+                        continue;
+                    }
+
+                    worldName = entry.getKey();
+                    reason = entry.getValue();
+                    iterator.remove();
+                    break;
+                }
+            }
+
+            if (worldName == null)
+                return;
+
+            World world = Bukkit.getWorld(worldName);
+
+            if (world == null) {
+                // The world was unloaded in the meantime; it was already saved by the unload task.
+                this.lastSaveTimes.remove(worldName);
+                continue;
+            }
+
+            saveWorldInternal(world, reason);
+            --savesLeft;
+        }
+    }
+
+    private void saveWorldInternal(World world, SaveReason reason) {
+        this.lastSaveTimes.put(world.getName(), System.currentTimeMillis());
+
+        try {
+            world.save();
+        } catch (Throwable error) {
+            module.getPlugin().getLogger().log(Level.SEVERE,
+                    "An unexpected error occurred while saving island world " + world.getName() +
+                            " (reason: " + reason.getConfigKey() + ")", error);
+            return;
+        }
+
+        module.getPlugin().getLogger().fine(() -> "Saved island world " + world.getName() +
+                " (reason: " + reason.getConfigKey() + ")");
+    }
+
+}

--- a/src/main/java/com/bgsoftware/ssbslimeworldmanager/save/SaveReason.java
+++ b/src/main/java/com/bgsoftware/ssbslimeworldmanager/save/SaveReason.java
@@ -1,0 +1,58 @@
+package com.bgsoftware.ssbslimeworldmanager.save;
+
+public enum SaveReason {
+
+    /**
+     * The world was saved by the interval-based auto save task.
+     */
+    AUTO_SAVE("auto-save"),
+
+    /**
+     * A player walked out of the area of the island.
+     */
+    ISLAND_LEAVE("island-leave"),
+
+    /**
+     * The last player of the island's world left it.
+     */
+    WORLD_EMPTY("world-empty"),
+
+    /**
+     * An upgrade was purchased for the island.
+     */
+    ISLAND_UPGRADE("island-upgrade"),
+
+    /**
+     * A schematic was pasted into the island.
+     */
+    SCHEMATIC_PASTE("schematic-paste"),
+
+    /**
+     * The biome of the island was changed.
+     */
+    BIOME_CHANGE("biome-change"),
+
+    /**
+     * The save was requested by another plugin or by the module itself, and therefore
+     * it cannot be disabled by the configuration.
+     */
+    MANUAL("manual");
+
+    private final String configKey;
+
+    SaveReason(String configKey) {
+        this.configKey = configKey;
+    }
+
+    public String getConfigKey() {
+        return configKey;
+    }
+
+    /**
+     * Whether this reason can be toggled in the `auto-save.triggers` section of the config.
+     */
+    public boolean isTrigger() {
+        return this != AUTO_SAVE && this != MANUAL;
+    }
+
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -47,3 +47,44 @@ unload-delay: 10
 # the world of the island is not loaded. When set to false, players will be
 # teleported to their spawn location instead.
 teleport-back-to-island: true
+
+# Whether the worlds of the island of a player should be loaded when they join the server.
+#
+# Turn this OFF on a network that runs SSBProxyBridge: there, the server a player joins is not
+# necessarily the server that hosts their island, and loading the world here would both waste
+# memory and take the lock of the world away from the server that is supposed to host it.
+preload-island-worlds-on-join: true
+
+# Settings related to saving island worlds while they are still loaded.
+#
+# An island world is only written to the data-source when it is unloaded, or when the server is
+# shut down gracefully. This means that if the server crashes, every loaded island is reverted
+# back to the state it had in its last save. Auto-saving closes that window.
+auto-save:
+  # Whether island worlds should be saved automatically.
+  # When disabled, islands are only saved on unload and on a graceful shutdown.
+  enabled: true
+  # The interval between two automatic saves of a loaded island world, in seconds.
+  # Set to 0 to disable interval-based saving; the triggers below will still work.
+  interval: 300
+  # The minimum amount of time that has to pass between two saves of the same island world, in seconds.
+  # A save that is requested before this delay has passed is not dropped - it is delayed until the
+  # delay has passed. This is what keeps a burst of triggers from turning into a burst of saves.
+  min-delay: 60
+  # The maximum amount of island worlds that can be saved in a single cycle (a cycle is one second).
+  # Increasing this makes saves happen sooner, at the cost of more work in a single tick.
+  saves-per-cycle: 1
+  # Events that request a save of an island world.
+  # All of the triggers respect the `min-delay` setting above, so enabling all of them cannot
+  # cause more saves than one every `min-delay` seconds per island.
+  triggers:
+    # A player walked out of the area of the island.
+    island-leave: true
+    # The last player of the island's world left it (changed world, teleported away or disconnected).
+    world-empty: true
+    # An upgrade was purchased for the island.
+    island-upgrade: true
+    # A schematic was pasted into the island (island creation, /is regen, ...).
+    schematic-paste: true
+    # The biome of the island was changed.
+    biome-change: false


### PR DESCRIPTION
Loaded island worlds are now saved periodically and on relevant gameplay triggers instead of only on unload or graceful shutdown, and world loading failures now surface as SlimeWorldLoadException rather than hanging the caller. Island world preloading on join can be disabled for networks running SSBProxyBridge, where the server a player joins does not necessarily host their island.